### PR TITLE
chore: use new repo URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = [
     "Volker Mische <volker.mische@gmail.com>"
 ]
-repository = "https://github.com/vmx/serde_ipld_dagjson"
+repository = "https://github.com/ipld/serde_ipld_dagjson"
 edition = "2021"
 description = "IPLD DAG-JSON support for Serde."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The repository was moved from my personal account to the ipld org account, reflect that in the Cargo metadata.