### PR TITLE
feat: implement Codec trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,13 +59,13 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6f85d53216cdc216013670266c6b2a3ec8ddd3eaa077ee5042d71c2d5fa775"
+checksum = "19865d6ca8b0b063f589b3b747e965e191b404564a1d64ae9f0b56428d6de6b8"
 dependencies = [
- "anyhow",
  "cid",
  "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -134,9 +128,9 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -152,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -165,7 +159,6 @@ dependencies = [
 name = "serde_ipld_dagjson"
 version = "0.1.1"
 dependencies = [
- "cid",
  "ipld-core",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,9 @@ license = "MIT OR Apache-2.0"
 categories = ["data-structures", "encoding"]
 
 [dependencies]
-cid = { version = "0.11.0", features = ["serde-codec"] }
+ipld-core = { version = "0.3.1", features = ["serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = { version = "1.0.111", features = ["float_roundtrip"] }
 
 [dev-dependencies]
-ipld-core = { version = "0.2.0", features = ["serde"] }
 serde_bytes = "0.11.14"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,42 @@
+use std::io::{BufRead, Write};
+
+use ipld_core::{
+    cid::Cid,
+    codec::{Codec, Links},
+    serde::ExtractLinks,
+};
+
+use serde::{de::Deserialize, ser::Serialize};
+
+use crate::{de::Deserializer, error::CodecError};
+
+/// DAG-JSON implementation of ipld-core's `Codec` trait.
+pub struct DagJsonCodec;
+
+impl<T> Codec<T> for DagJsonCodec
+where
+    T: for<'a> Deserialize<'a> + Serialize,
+{
+    const CODE: u64 = 0x129;
+    type Error = CodecError;
+
+    fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error> {
+        Ok(crate::from_reader(reader)?)
+    }
+
+    fn encode<W: Write>(writer: W, data: &T) -> Result<(), Self::Error> {
+        Ok(crate::to_writer(writer, data)?)
+    }
+}
+
+impl Links for DagJsonCodec {
+    type LinksError = CodecError;
+
+    fn links(data: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError> {
+        let mut json_deserializer = serde_json::Deserializer::from_slice(data);
+        let deserializer = Deserializer::new(&mut json_deserializer);
+        Ok(ExtractLinks::deserialize(deserializer)?
+            .into_vec()
+            .into_iter())
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,7 @@
 //! Deserialization.
 use std::{fmt, io};
 
-use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
+use ipld_core::cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
 use serde::{
     de::{
         self,

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,3 +57,44 @@ impl From<serde_json::Error> for DecodeError {
         Self::Message(error.to_string())
     }
 }
+
+/// Encode and Decode error combined.
+#[derive(Debug)]
+pub enum CodecError {
+    /// A decoding error.
+    Decode(DecodeError),
+    /// An encoding error.
+    Encode(EncodeError),
+    /// An error from within `serde_json`.
+    SerdeJson(String),
+}
+
+impl fmt::Display for CodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode(error) => write!(f, "decode error: {}", error),
+            Self::Encode(error) => write!(f, "encode error: {}", error),
+            Self::SerdeJson(error) => write!(f, "serde_json error: {}", error),
+        }
+    }
+}
+
+impl std::error::Error for CodecError {}
+
+impl From<DecodeError> for CodecError {
+    fn from(error: DecodeError) -> Self {
+        Self::Decode(error)
+    }
+}
+
+impl From<EncodeError> for CodecError {
+    fn from(error: EncodeError) -> Self {
+        Self::Encode(error)
+    }
+}
+
+impl From<serde_json::Error> for CodecError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::SerdeJson(error.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! DAG-JSON serialization and deserialization.
+pub mod codec;
 pub mod de;
 pub mod error;
 pub mod ser;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,7 +1,7 @@
 //! Serialization.
 use std::{fmt, io};
 
-use cid::{multibase::Base, serde::CID_SERDE_PRIVATE_IDENTIFIER, Cid};
+use ipld_core::cid::{multibase::Base, serde::CID_SERDE_PRIVATE_IDENTIFIER, Cid};
 use serde::{ser, Serialize};
 
 use crate::{

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,4 +1,4 @@
-use cid::{multibase::Base, Cid};
+use ipld_core::cid::{multibase::Base, Cid};
 use serde::{de, Deserialize, Serialize};
 
 /// Result of deserializing a DAG-JSON map consisting of the reserved key `/`.

--- a/tests/codec.rs
+++ b/tests/codec.rs
@@ -1,0 +1,38 @@
+use std::iter;
+
+use ipld_core::{
+    cid::Cid,
+    codec::{Codec, Links},
+    ipld,
+    ipld::Ipld,
+};
+use serde_ipld_dagjson::codec::DagJsonCodec;
+
+#[test]
+fn test_codec_encode() {
+    let data = "hello world!".to_string();
+    let expected = br#""hello world!""#;
+
+    let encoded = DagJsonCodec::encode_to_vec(&data).unwrap();
+    assert_eq!(encoded, expected);
+}
+
+#[test]
+fn test_codec_decode() {
+    let data = br#""hello world!""#;
+    let expected = "hello world!".to_string();
+
+    let decoded: String = DagJsonCodec::decode_from_slice(data).unwrap();
+    assert_eq!(decoded, expected);
+}
+
+#[test]
+fn test_codec_links() {
+    let cid = Cid::try_from("bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy").unwrap();
+    let data: Ipld = ipld!({"some": {"nested": cid}, "or": [cid, cid], "foo": true});
+    let expected = iter::repeat(cid).take(3).collect::<Vec<_>>();
+    let encoded = DagJsonCodec::encode_to_vec(&data).unwrap();
+
+    let links = DagJsonCodec::links(&encoded).unwrap().collect::<Vec<_>>();
+    assert_eq!(links, expected);
+}

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,7 +1,6 @@
 use std::{collections::BTreeMap, str::FromStr};
 
-use cid::Cid;
-use ipld_core::ipld::Ipld;
+use ipld_core::{cid::Cid, ipld::Ipld};
 use serde_bytes::{ByteArray, ByteBuf};
 use serde_ipld_dagjson::{de, to_vec, DecodeError};
 

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, str::FromStr};
 
-use cid::Cid;
+use ipld_core::cid::Cid;
 use serde::Serialize;
 use serde_bytes::{ByteBuf, Bytes};
 use serde_ipld_dagjson::to_vec;


### PR DESCRIPTION
The `Codec` trait from `ipld-core` allows unified access for encoding, decoding and extracting links of encoded IPLD data independent of the codec.