### PR TITLE
chore: upgrade to latest ipld-core 0.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 categories = ["data-structures", "encoding"]
 
 [dependencies]
-ipld-core = { version = "0.3.1", features = ["serde"] }
+ipld-core = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = { version = "1.0.111", features = ["float_roundtrip"] }
 


### PR DESCRIPTION
BREAKING CHANGE: `ipld-core` contains traits and different versions of traits don't play well together, hence it's a breaking change.