### PR TITLE
Derive common traits for `DagJsonCodec`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -11,6 +11,7 @@ use serde::{de::Deserialize, ser::Serialize};
 use crate::{de::Deserializer, error::CodecError};
 
 /// DAG-JSON implementation of ipld-core's `Codec` trait.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DagJsonCodec;
 
 impl<T> Codec<T> for DagJsonCodec


### PR DESCRIPTION
See https://github.com/ipld/serde_ipld_dagcbor/pull/32 for more (this is the DAG-JSON equivalent)