### PR TITLE
feat: make the DAG-JSON multicodec code public

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -8,7 +8,7 @@ use ipld_core::{
 
 use serde::{de::Deserialize, ser::Serialize};
 
-use crate::{de::Deserializer, error::CodecError};
+use crate::{de::Deserializer, error::CodecError, DAG_JSON_CODE};
 
 /// DAG-JSON implementation of ipld-core's `Codec` trait.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -18,7 +18,7 @@ impl<T> Codec<T> for DagJsonCodec
 where
     T: for<'a> Deserialize<'a> + Serialize,
 {
-    const CODE: u64 = 0x129;
+    const CODE: u64 = DAG_JSON_CODE;
     type Error = CodecError;
 
     fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,6 @@ mod shared;
 pub use crate::de::{from_reader, from_slice, Deserializer};
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::ser::{to_vec, to_writer, Serializer};
+
+/// The multicodec code for DAG-JSON.
+pub const DAG_JSON_CODE: u64 = 0x129;


### PR DESCRIPTION
There is no easy way to get the DAG-JSON multicodec code from this library. This commits adds a public constant called `DAG_JSON_CODE`.